### PR TITLE
added XFF to structs

### DIFF
--- a/rule/stack/structs.go
+++ b/rule/stack/structs.go
@@ -56,6 +56,7 @@ type Details struct {
 	AccountId           string        `json:"AccountId,omitempty"`
 	AccountGroup        string        `json:"AccountGroup,omitempty"`
 	MinimumAppIdVersion string        `json:"MinAppIdVersion,omitempty"`
+	LookupXForwardedFor string        `json:"LookupXForwardedFor,omitempty"`
 	Profile             ProfileConfig `json:"Profiles"`
 
 	UpdateToken string `json:"UpdateToken,omitempty"`


### PR DESCRIPTION
## Description

Added XFF support to the Details struct

## Motivation and Context

This is a new feature supported by fwaas, so we need terraform provider to support it as well.

## How Has This Been Tested?

I tested the feature support on my local test environment.
I created test rule-stack using terraform provider and saw visually the xff checkbox marked.
It's not marked by default.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

![Screen Shot 2022-07-06 at 4 08 53 PM](https://user-images.githubusercontent.com/3106584/177876692-416a3da3-2a11-4e0d-a2d3-4ea186e148b2.png)

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
