### PR TITLE
fix an issue where global rulestack creation gets stuck

### DIFF
--- a/ngfw/aws/permissions.go
+++ b/ngfw/aws/permissions.go
@@ -227,7 +227,6 @@ func (c *Client) RefreshGlobalRulestackAdminJwt(ctx context.Context) error {
 	}
 
 	svc := sts.New(sess)
-	results := make(chan error)
 
 	// Get global rulestack JWT.
 	if c.GraArn == "" {
@@ -252,11 +251,9 @@ func (c *Client) RefreshGlobalRulestackAdminJwt(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-
 	tNow := time.Now()
 	c.GlobalRulestackAdminJwtExpTime = tNow.Add(time.Duration(ans.Resp.ExpiryTime) * time.Minute)
 	c.GlobalRulestackAdminJwt = ans.Resp.Jwt
 	c.GlobalRulestackSubscriptionKey = ans.Resp.SubscriptionKey
-	results <- nil
 	return nil
 }


### PR DESCRIPTION
## Description

fix an issue where global rulestack creation gets stuck

## Motivation and Context

global rulestack gets stuck post recent sdk changes

## How Has This Been Tested?

created global rulestack

## Screenshots (if appropriate)


## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes if appropriate.
- [ x] All new and existing tests passed.
